### PR TITLE
Add id and const functions

### DIFF
--- a/function/function.go
+++ b/function/function.go
@@ -1,5 +1,17 @@
 package function
 
+// Const always returns the first argument, disregarding the second.
+func Const[T, U any](t T) func(U) T {
+	return func(_ U) T {
+		return t
+	}
+}
+
+// Id is the identity function and will return its argument.
+func Id[T any](t T) T {
+	return t
+}
+
 // Inspect calls the given function with the provided value
 // and returns the unchanged value.
 func Inspect[T any](fn func(T)) func(T) T {

--- a/function/function_test.go
+++ b/function/function_test.go
@@ -9,6 +9,30 @@ import (
 	"github.com/JustinKnueppel/go-fp/tuple"
 )
 
+func ExampleConst() {
+	fp.Pipe2(
+		fp.Const[int, string](5),
+		fp.Inspect(func(x int) {
+			fmt.Println(x)
+		}),
+	)("Hello world!")
+
+	// Output:
+	// 5
+}
+
+func ExampleId() {
+	fp.Pipe2(
+		fp.Id[int],
+		fp.Inspect(func(x int) {
+			fmt.Println(x)
+		}),
+	)(5)
+
+	// Output:
+	// 5
+}
+
 func ExampleInspect() {
 	double := func(x int) int { return x * 2 }
 	fp.Pipe2(


### PR DESCRIPTION
These two functions are primarily used in function composition and are more common in proofs than in programming. They do however still have use