### PR TITLE
Add pattern function for pairs

### DIFF
--- a/tuple/pair.go
+++ b/tuple/pair.go
@@ -42,3 +42,9 @@ func MapRight[T, U1, U2 any](fn func(U1) U2) func(Pair[T, U1]) Pair[T, U2] {
 		return NewPair[T, U2](p.fst)(fn(p.snd))
 	}
 }
+
+// Pattern returns each value of the pair using Go multiple return.
+// This allows pattern matching like syntax with x, y := Pattern(pair).
+func Pattern[T, U any](pair Pair[T, U]) (T, U) {
+	return pair.fst, pair.snd
+}

--- a/tuple/pair_test.go
+++ b/tuple/pair_test.go
@@ -84,3 +84,12 @@ func ExampleMapRight() {
 	// (foo 2)
 	// (bar 10)
 }
+
+func ExamplePattern() {
+	pair := tuple.NewPair[int, string](1)("foo")
+	idx, val := tuple.Pattern(pair)
+	fmt.Printf("%d: %s", idx, val)
+
+	// Output
+	// 1: foo
+}


### PR DESCRIPTION
This allows pattern match like syntax of `x, y := tuple.Pattern(pair)`