### PR TITLE
Add error to either function set

### DIFF
--- a/either/error_to_either.go
+++ b/either/error_to_either.go
@@ -1,0 +1,121 @@
+package either
+
+// ErrorToEither0 returns a 0-arity function that returns a value or an error, and
+// converts the return value to an Either[error, T].
+func ErrorToEither0[T any](fn func() (T, error)) func() Either[error, T] {
+	return func() Either[error, T] {
+		t, err := fn()
+		if err != nil {
+			return Left[error, T](err)
+		}
+		return Right[error](t)
+	}
+}
+
+// ErrorToEither1 returns a 1-arity function that returns a value or an error, and
+// converts the return value to an Either[error, T].
+func ErrorToEither1[A, T any](fn func(A) (T, error)) func(A) Either[error, T] {
+	return func(a A) Either[error, T] {
+		t, err := fn(a)
+		if err != nil {
+			return Left[error, T](err)
+		}
+		return Right[error](t)
+	}
+}
+
+// ErrorToEither2 returns a 2-arity function that returns a value or an error, and
+// converts the return value to an Either[error, T].
+func ErrorToEither2[A, B, T any](fn func(A, B) (T, error)) func(A, B) Either[error, T] {
+	return func(a A, b B) Either[error, T] {
+		t, err := fn(a, b)
+		if err != nil {
+			return Left[error, T](err)
+		}
+		return Right[error](t)
+	}
+}
+
+// ErrorToEither3 returns a 3-arity function that returns a value or an error, and
+// converts the return value to an Either[error, T].
+func ErrorToEither3[A, B, C, T any](fn func(A, B, C) (T, error)) func(A, B, C) Either[error, T] {
+	return func(a A, b B, c C) Either[error, T] {
+		t, err := fn(a, b, c)
+		if err != nil {
+			return Left[error, T](err)
+		}
+		return Right[error](t)
+	}
+}
+
+// ErrorToEither4 returns a 4-arity function that returns a value or an error, and
+// converts the return value to an Either[error, T].
+func ErrorToEither4[A, B, C, D, T any](fn func(A, B, C, D) (T, error)) func(A, B, C, D) Either[error, T] {
+	return func(a A, b B, c C, d D) Either[error, T] {
+		t, err := fn(a, b, c, d)
+		if err != nil {
+			return Left[error, T](err)
+		}
+		return Right[error](t)
+	}
+}
+
+// ErrorToEither5 returns a 5-arity function that returns a value or an error, and
+// converts the return value to an Either[error, T].
+func ErrorToEither5[A, B, C, D, E, T any](fn func(A, B, C, D, E) (T, error)) func(A, B, C, D, E) Either[error, T] {
+	return func(a A, b B, c C, d D, e E) Either[error, T] {
+		t, err := fn(a, b, c, d, e)
+		if err != nil {
+			return Left[error, T](err)
+		}
+		return Right[error](t)
+	}
+}
+
+// ErrorToEither6 returns a 6-arity function that returns a value or an error, and
+// converts the return value to an Either[error, T].
+func ErrorToEither6[A, B, C, D, E, F, T any](fn func(A, B, C, D, E, F) (T, error)) func(A, B, C, D, E, F) Either[error, T] {
+	return func(a A, b B, c C, d D, e E, f F) Either[error, T] {
+		t, err := fn(a, b, c, d, e, f)
+		if err != nil {
+			return Left[error, T](err)
+		}
+		return Right[error](t)
+	}
+}
+
+// ErrorToEither7 returns a 7-arity function that returns a value or an error, and
+// converts the return value to an Either[error, T].
+func ErrorToEither7[A, B, C, D, E, F, G, T any](fn func(A, B, C, D, E, F, G) (T, error)) func(A, B, C, D, E, F, G) Either[error, T] {
+	return func(a A, b B, c C, d D, e E, f F, g G) Either[error, T] {
+		t, err := fn(a, b, c, d, e, f, g)
+		if err != nil {
+			return Left[error, T](err)
+		}
+		return Right[error](t)
+	}
+}
+
+// ErrorToEither8 returns a 8-arity function that returns a value or an error, and
+// converts the return value to an Either[error, T].
+func ErrorToEither8[A, B, C, D, E, F, G, H, T any](fn func(A, B, C, D, E, F, G, H) (T, error)) func(A, B, C, D, E, F, G, H) Either[error, T] {
+	return func(a A, b B, c C, d D, e E, f F, g G, h H) Either[error, T] {
+		t, err := fn(a, b, c, d, e, f, g, h)
+		if err != nil {
+			return Left[error, T](err)
+		}
+		return Right[error](t)
+	}
+}
+
+// ErrorToEither9 returns a 9-arity function that returns a value or an error, and
+// converts the return value to an Either[error, T].
+func ErrorToEither9[A, B, C, D, E, F, G, H, I, T any](fn func(A, B, C, D, E, F, G, H, I) (T, error)) func(A, B, C, D, E, F, G, H, I) Either[error, T] {
+	return func(a A, b B, c C, d D, e E, f F, g G, h H, i I) Either[error, T] {
+		t, err := fn(a, b, c, d, e, f, g, h, i)
+		if err != nil {
+			return Left[error, T](err)
+		}
+		return Right[error](t)
+	}
+}

--- a/either/error_to_either_test.go
+++ b/either/error_to_either_test.go
@@ -1,0 +1,168 @@
+package either_test
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/JustinKnueppel/go-fp/either"
+)
+
+func ExampleErrorToEither0() {
+	good := func() (int, error) {
+		return 5, nil
+	}
+	bad := func() (int, error) {
+		return 0, errors.New("failed")
+	}
+
+	fmt.Println(either.ErrorToEither0(good)())
+	fmt.Println(either.ErrorToEither0(bad)())
+
+	// Output:
+	// Right 5
+	// Left failed
+}
+
+func ExampleErrorToEither1() {
+	good := func(x int) (int, error) {
+		return x, nil
+	}
+	bad := func(int) (int, error) {
+		return 0, errors.New("failed")
+	}
+
+	fmt.Println(either.ErrorToEither1(good)(1))
+	fmt.Println(either.ErrorToEither1(bad)(1))
+
+	// Output:
+	// Right 1
+	// Left failed
+}
+
+func ExampleErrorToEither2() {
+	good := func(_, x int) (int, error) {
+		return x, nil
+	}
+	bad := func(int, int) (int, error) {
+		return 0, errors.New("failed")
+	}
+
+	fmt.Println(either.ErrorToEither2(good)(1, 2))
+	fmt.Println(either.ErrorToEither2(bad)(1, 2))
+
+	// Output:
+	// Right 2
+	// Left failed
+}
+
+func ExampleErrorToEither3() {
+	good := func(_, _, x int) (int, error) {
+		return x, nil
+	}
+	bad := func(int, int, int) (int, error) {
+		return 0, errors.New("failed")
+	}
+
+	fmt.Println(either.ErrorToEither3(good)(1, 2, 3))
+	fmt.Println(either.ErrorToEither3(bad)(1, 2, 3))
+
+	// Output:
+	// Right 3
+	// Left failed
+}
+
+func ExampleErrorToEither4() {
+	good := func(_, _, _, x int) (int, error) {
+		return x, nil
+	}
+	bad := func(int, int, int, int) (int, error) {
+		return 0, errors.New("failed")
+	}
+
+	fmt.Println(either.ErrorToEither4(good)(1, 2, 3, 4))
+	fmt.Println(either.ErrorToEither4(bad)(1, 2, 3, 4))
+
+	// Output:
+	// Right 4
+	// Left failed
+}
+
+func ExampleErrorToEither5() {
+	good := func(_, _, _, _, x int) (int, error) {
+		return x, nil
+	}
+	bad := func(int, int, int, int, int) (int, error) {
+		return 0, errors.New("failed")
+	}
+
+	fmt.Println(either.ErrorToEither5(good)(1, 2, 3, 4, 5))
+	fmt.Println(either.ErrorToEither5(bad)(1, 2, 3, 4, 5))
+
+	// Output:
+	// Right 5
+	// Left failed
+}
+
+func ExampleErrorToEither6() {
+	good := func(_, _, _, _, _, x int) (int, error) {
+		return x, nil
+	}
+	bad := func(int, int, int, int, int, int) (int, error) {
+		return 0, errors.New("failed")
+	}
+
+	fmt.Println(either.ErrorToEither6(good)(1, 2, 3, 4, 5, 6))
+	fmt.Println(either.ErrorToEither6(bad)(1, 2, 3, 4, 5, 6))
+
+	// Output:
+	// Right 6
+	// Left failed
+}
+
+func ExampleErrorToEither7() {
+	good := func(_, _, _, _, _, _, x int) (int, error) {
+		return x, nil
+	}
+	bad := func(int, int, int, int, int, int, int) (int, error) {
+		return 0, errors.New("failed")
+	}
+
+	fmt.Println(either.ErrorToEither7(good)(1, 2, 3, 4, 5, 6, 7))
+	fmt.Println(either.ErrorToEither7(bad)(1, 2, 3, 4, 5, 6, 7))
+
+	// Output:
+	// Right 7
+	// Left failed
+}
+
+func ExampleErrorToEither8() {
+	good := func(_, _, _, _, _, _, _, x int) (int, error) {
+		return x, nil
+	}
+	bad := func(int, int, int, int, int, int, int, int) (int, error) {
+		return 0, errors.New("failed")
+	}
+
+	fmt.Println(either.ErrorToEither8(good)(1, 2, 3, 4, 5, 6, 7, 8))
+	fmt.Println(either.ErrorToEither8(bad)(1, 2, 3, 4, 5, 6, 7, 8))
+
+	// Output:
+	// Right 8
+	// Left failed
+}
+
+func ExampleErrorToEither9() {
+	good := func(_, _, _, _, _, _, _, _, x int) (int, error) {
+		return x, nil
+	}
+	bad := func(int, int, int, int, int, int, int, int, int) (int, error) {
+		return 0, errors.New("failed")
+	}
+
+	fmt.Println(either.ErrorToEither9(good)(1, 2, 3, 4, 5, 6, 7, 8, 9))
+	fmt.Println(either.ErrorToEither9(bad)(1, 2, 3, 4, 5, 6, 7, 8, 9))
+
+	// Output:
+	// Right 9
+	// Left failed
+}


### PR DESCRIPTION
This function set helps convert functions of the structure

```go
func Foo(...) (value, error)
```

into the provided `Either[error, T]` type ie

```go
func Foo(...) either.Either[error, T]
```