### PR TITLE
Add TakeWhile and DropWhile

### DIFF
--- a/slice/slice.go
+++ b/slice/slice.go
@@ -137,6 +137,23 @@ func Drop[T any](n int) func([]T) []T {
 	}
 }
 
+// DropWhile drops elements while the predicate remains true, and returns the remaining elements.
+func DropWhile[T any](predicate func(T) bool) func([]T) []T {
+	return func(ts []T) []T {
+		i := 0
+		for i < len(ts) && predicate(ts[i]) {
+			i++
+		}
+
+		out := []T{}
+		for i < len(ts) {
+			out = append(out, ts[i])
+			i++
+		}
+		return out
+	}
+}
+
 // IsEmpty returns true if the slice is empty.
 func IsEmpty[T any](ts []T) bool {
 	return Length(ts) == 0
@@ -761,6 +778,18 @@ func Take[T any](n int) func([]T) []T {
 		}
 		out := []T{}
 		for i := 0; i < n && i < Length(ts); i++ {
+			out = append(out, ts[i])
+		}
+		return out
+	}
+}
+
+// TakeWhile takes elements from the beginning of the slice as long as the predicate returns true.
+// all remaining elements will be dropped.
+func TakeWhile[T any](predicate func(T) bool) func([]T) []T {
+	return func(ts []T) []T {
+		out := []T{}
+		for i := 0; i < len(ts) && predicate(ts[i]); i++ {
 			out = append(out, ts[i])
 		}
 		return out

--- a/slice/slice_test.go
+++ b/slice/slice_test.go
@@ -345,6 +345,44 @@ func ExampleDrop() {
 	// Drop yields empty slice when n > length: []
 }
 
+func ExampleDropWhile() {
+	isEven := func(x int) bool { return x%2 == 0 }
+
+	fp.Pipe2(
+		slice.DropWhile(isEven),
+		fp.Inspect(func(xs []int) {
+			fmt.Println(xs)
+		}),
+	)([]int{})
+
+	fp.Pipe2(
+		slice.DropWhile(isEven),
+		fp.Inspect(func(xs []int) {
+			fmt.Println(xs)
+		}),
+	)([]int{2, 4})
+
+	fp.Pipe2(
+		slice.DropWhile(isEven),
+		fp.Inspect(func(xs []int) {
+			fmt.Println(xs)
+		}),
+	)([]int{2, 4, 5, 6, 7})
+
+	fp.Pipe2(
+		slice.DropWhile(isEven),
+		fp.Inspect(func(xs []int) {
+			fmt.Println(xs)
+		}),
+	)([]int{1, 2, 4, 5, 6, 7})
+
+	// Output:
+	// []
+	// []
+	// [5 6 7]
+	// [1 2 4 5 6 7]
+}
+
 func ExampleIsEmpty() {
 	fp.Pipe2(
 		slice.IsEmpty[int],
@@ -1888,6 +1926,44 @@ func ExampleTake() {
 	// Returns all elements of slice: [1 2]
 	// Returns all elements of slice: [1]
 	// Negative numbers return empty slice: []
+}
+
+func ExampleTakeWhile() {
+	isEven := func(x int) bool { return x%2 == 0 }
+
+	fp.Pipe2(
+		slice.TakeWhile(isEven),
+		fp.Inspect(func(xs []int) {
+			fmt.Println(xs)
+		}),
+	)([]int{})
+
+	fp.Pipe2(
+		slice.TakeWhile(isEven),
+		fp.Inspect(func(xs []int) {
+			fmt.Println(xs)
+		}),
+	)([]int{1, 3})
+
+	fp.Pipe2(
+		slice.TakeWhile(isEven),
+		fp.Inspect(func(xs []int) {
+			fmt.Println(xs)
+		}),
+	)([]int{2, 4, 5, 6, 7})
+
+	fp.Pipe2(
+		slice.TakeWhile(isEven),
+		fp.Inspect(func(xs []int) {
+			fmt.Println(xs)
+		}),
+	)([]int{1, 2, 4, 5, 6, 7})
+
+	// Output:
+	// []
+	// []
+	// [2 4]
+	// []
 }
 
 func ExampleTranspose() {


### PR DESCRIPTION
Rather than taking or dropping the first n elements, do so until a predicate is no longer satisfied.